### PR TITLE
Don't render the icon when swipe event aborted.

### DIFF
--- a/app/src/main/java/net/nemanjakovacevic/recyclerviewswipetodelete/MainActivity.java
+++ b/app/src/main/java/net/nemanjakovacevic/recyclerviewswipetodelete/MainActivity.java
@@ -131,6 +131,12 @@ public class MainActivity extends AppCompatActivity {
                     // not interested in those
                     return;
                 }
+                
+                // Don't render the icon when a user aborts a swipe.
+                if (!isCurrentlyActive)
+                {
+                    return;
+                }
 
                 if (!initiated) {
                     init();


### PR DESCRIPTION
When the user aborts a swipe event (i.e. they don't swipe all the way to the left or if they drag the item back to the right) the icon/drawable still remains rendered in on the item. This bug has been fixed. 