### PR TITLE
Fixed API19 crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
I fixed app crash with message "You need to use a Theme.AppCompat theme (or descendant) with this activity". Now it's work on API level 19